### PR TITLE
remove Deprecation: 

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,7 @@ function ensure($value): Ensurance
  * @return BooleanEnsurance
  * @throws Throwable
  */
-function enforce(bool $condition, string $message = null): BooleanEnsurance
+function enforce(bool $condition, ?string $message = null): BooleanEnsurance
 {
     $error = new AssertionError($message ?? 'Assertion failed');
 


### PR DESCRIPTION
Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead